### PR TITLE
don't start Xvfb for each run

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,18 @@ See [this blogpost](https://blog.andyet.com/2014/09/29/testing-webrtc-applicatio
 To run it inside Xvfb, just use `xvfb-run ./test-runner.sh`.
 
 #Required software
-* xvfb
+* Xvfb
 * sqlite3
 * python-pip
 * firefox
   * mozrunner (via pip/easy\_install)
+
+#Running
+* start Xvfb
+```Xvfb :10``
+* set the DISPLAY variable to the same port as used above
+``export DISPLAY=:10``
+* run test-runner as often as you would like
 
 #Recommended reading
 The webrtc team has published two excellent blog posts on automatted interop testing between Firefox and Chrome:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ webrtc-tester
 WebRTC Deployment Testing Toolkit
 
 See [this blogpost](https://blog.andyet.com/2014/09/29/testing-webrtc-applications) about how we use this for testing [Talky](https://talky.io) deployments.
+To run it inside Xvfb, just use `xvfb-run ./test-runner.sh`.
 
 #Required software
 * xvfb

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ To run it inside Xvfb, just use `xvfb-run ./test-runner.sh`.
   * mozrunner (via pip/easy\_install)
 
 #Running
-* start Xvfb
-```Xvfb :10``
-* set the DISPLAY variable to the same port as used above
-``export DISPLAY=:10``
+* start Xvfb:
+```Xvfb :10```
+* set the DISPLAY variable to the same port as used above:
+```export DISPLAY=:10```
 * run test-runner as often as you would like
 
 #Recommended reading

--- a/test-browser.sh
+++ b/test-browser.sh
@@ -20,7 +20,7 @@ function browser_pids() {
   "chromium-browser")
     ps axuwww|grep $D|grep c[h]romium-browser|awk '{print $2}'
     ;;
-  "firefox")
+  "firefox" | "firefox-trunk" )
     ps axuwww|grep $D|grep f[i]refox|awk '{print $2}'
     ;;
   esac
@@ -61,7 +61,7 @@ case "$BROWSER" in
         INSERT INTO ItemTable (key, value) VALUES ("skipHaircheck", "true");
 EOF
     ;;
-  "firefox")
+  "firefox" | "firefox-trunk")
     REVERSEHOST=`echo ${HOST} | rev` 
     sqlite3 "${D}/webappsstore.sqlite" << EOF
         CREATE TABLE webappsstore2 (scope TEXT, key TEXT, value TEXT, secure INTEGER, owner TEXT);
@@ -77,17 +77,9 @@ esac
 LOG_FILE="${D}/browser.log"
 touch $LOG_FILE
 
-# setup xvfb
-XVFB="xvfb-run -a -e $LOG_FILE -s '-screen 0 1024x768x24'"
-if [ -n "$DISPLAY" ]; then
-  XVFB=""
-fi
-
-# run xvfb
-# "eval" below is required by $XVFB containing a quoted argument.
 case "$BROWSER" in
   "google-chrome" | "google-chrome-stable" | "google-chrome-beta" | "google-chrome-unstable" | "chromium-browser")
-    eval $XVFB $BROWSER \
+    $BROWSER \
       --enable-logging=stderr \
       --no-first-run \
       --no-default-browser-check \
@@ -99,8 +91,8 @@ case "$BROWSER" in
       "${URL}" > $LOG_FILE 2>&1 &
     PID=$!
   ;;
-  "firefox")
-    eval $XVFB mozrunner \
+  "firefox" | "firefox-trunk")
+    mozrunner \
       -p ${D} \
       --binary ${BROWSER} \
       --app-arg=${URL} > $LOG_FILE 2>&1 &

--- a/test-cron.sh
+++ b/test-cron.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# start Xvfb
+# TODO: steal the automagic servernum from xvfb-run
+SERVERNUM=99
+DISPLAY=:$SERVERNUM
+Xvfb $DISPLAY >/dev/null 2>&1 &
+
 # Argument 1: host
 if [ -z "$1" ]; then
     echo "missing 'host' argument (string)"

--- a/test-runner.sh
+++ b/test-runner.sh
@@ -37,5 +37,6 @@ if wait $pidwatcher 2>/dev/null; then
   echo "--- timedout"
   cat log1.log
   cat log2.log
+  exit 1
 fi
 # do nothing in the case of success

--- a/test-runner.sh
+++ b/test-runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 TIMEOUT="90"
-DISPLAY=
-HOST="beta.talky.io"
+#DISPLAY=
+HOST="no.such.talky.io"
 ROOM="automatedtesting_${RANDOM}"
 COND="P2P connected" # talky
 #COND="data channel open" # talky pro
@@ -11,14 +11,8 @@ COND="P2P connected" # talky
 
 # make sure we kill any Xvfb instances
 function cleanup() {
-  function xvfb_pids() {
-    ps x -o "%r %p %c" | grep X[v]fb | grep $$ | awk '{print $2}'
-  }
   exec 3>&2
   exec 2>/dev/null
-  while [ ! -z "$(xvfb_pids)" ]; do
-    kill $(xvfb_pids)
-  done
   pkill -HUP -P $pidwatch
   pkill -HUP -P $pidwatch2
   exec 2>&3


### PR DESCRIPTION
it seems Xvfb doesn't like to be started often so the strategy from turn-prober is bad when running under cron / continually.

@stongo
